### PR TITLE
Feat: 매칭 기능 지원을 위한 이력서 스택 조회 로직 구현

### DIFF
--- a/backend/src/main/java/com/example/pproject/resume/repository/ResumeRepository.java
+++ b/backend/src/main/java/com/example/pproject/resume/repository/ResumeRepository.java
@@ -13,4 +13,8 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
     // 특정 유저의 대표 이력서 조회
     Optional<Resume> findByUserIdAndPrimaryTrue(Integer userId);
+
+    Optional<Resume> findByMemberIdAndIsPrimaryTrue(Long memberId); // 대표 이력서 찾기
+
+    Optional<Resume> findFirstByMemberIdOrderByUpdatedAtDesc(Long memberId); // 최근 이력서 찾기
 }

--- a/backend/src/main/java/com/example/pproject/resume/service/ResumeSkillService.java
+++ b/backend/src/main/java/com/example/pproject/resume/service/ResumeSkillService.java
@@ -1,0 +1,65 @@
+package com.example.pproject.resume.service;
+
+import com.example.pproject.resume.entity.Resume;
+import com.example.pproject.resume.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResumeSkillService { // implements 제거함
+
+    private final ResumeRepository resumeRepository;
+
+    /**
+     * 1. 특정 회원의 기술 스택 조회 (대표 이력서 기준)
+     * (나중에 인터페이스가 생기면 @Override 붙이세요)
+     */
+    public Set<String> getSkillsByMemberId(Long memberId) {
+        // 대표 이력서 찾기
+        Optional<Resume> primaryResume = resumeRepository.findByMemberIdAndIsPrimaryTrue(memberId);
+
+        // 없으면 최근 수정된 이력서 찾기
+        if (primaryResume.isEmpty()) {
+            primaryResume = resumeRepository.findFirstByMemberIdOrderByUpdatedAtDesc(memberId);
+        }
+
+        return primaryResume
+                .map(this::extractSkillsFromResume)
+                .orElse(new HashSet<>());
+    }
+
+    /**
+     * 2. 특정 이력서의 기술 스택 조회
+     */
+    public Set<String> getSkillsByResumeId(Long resumeId) {
+        return resumeRepository.findById(resumeId)
+                .map(this::extractSkillsFromResume)
+                .orElse(new HashSet<>());
+    }
+
+    // [내부 로직] 문자열 파싱
+    private Set<String> extractSkillsFromResume(Resume resume) {
+        String stackString = resume.getReStack();
+
+        if (stackString == null || stackString.isBlank()) {
+            return new HashSet<>();
+        }
+
+        String[] skills = stackString.split("[,/|;]");
+
+        return Arrays.stream(skills)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
name: "기본 PR 템플릿"
about: 작업 내용을 명확히 공유하고, CI 통과를 미리 점검합니다.
title: '[FEAT] 매칭 서비스를 위한 이력서 기술 스택 추출 로직 구현'
labels: ''
assignees: ''

## 📝 설명 (Description)
- 채용 공고와 지원자 간의 매칭 점수 산출(Job 모듈 요청)을 위해, 이력서의 기술 스택(`re_stack`)을 추출하고 정규화하여 반환하는 로직을 구현했습니다.
- `Job` 모듈의 인터페이스가 아직 반영되지 않은 상태라, 컴파일 에러 방지를 위해 구현체 로직만 우선 독립적으로 작성했습니다.

## 🔗 관련 이슈 (Related Issue)
- (관련된 이슈 번호가 있다면 기재, 없으면 생략 가능)

## ✅ CI/CD Self-Check (필수)
- [x] **backend 폴더**에서 `./gradlew clean build`를 돌려보셨나요? (로컬 빌드 성공)
- [x] 불필요한 `System.out.println`이나 주석을 제거했나요?
- [x] `develop` 브랜치의 최신 코드를 반영(Rebase/Merge)했나요?

## 🛠️ Todo (작업 리스트)
- [x] `ResumeRepository`: 대표 이력서 및 최신 이력서 조회 쿼리 메서드 추가 (`findByMemberIdAndIsPrimaryTrue` 등)
- [x] `ResumeSkillService`: 이력서 스택 문자열 파싱(Split), 공백 제거, 소문자 변환 로직 구현
- [x] `CandidateSkillProvider` 인터페이스 규격에 맞춘 메서드(`getSkillsByMemberId`, `getSkillsByResumeId`) 구현

## 🎸 ETC
- **[Note]** 현재 `CandidateSkillProvider` 인터페이스 파일이 로컬에 없어 `implements` 키워드는 제외하고 푸시했습니다.
- 매칭 기능 담당자분께서 작업하실 때, `ResumeSkillService` 클래스에 `implements CandidateSkillProvider` 선언만 추가해서 연결해주시면 됩니다.