### PR TITLE
[RESUME] AI 분석 API 연동 / [REFACTOR] 이력서 기술스택 배열화 및 경력 필드 추가

### DIFF
--- a/backend/src/main/java/com/example/pproject/resume/controller/AiResumeController.java
+++ b/backend/src/main/java/com/example/pproject/resume/controller/AiResumeController.java
@@ -1,0 +1,32 @@
+package com.example.pproject.resume.controller;
+
+import com.example.pproject.global.response.ApiResponse;
+import com.example.pproject.resume.service.AiResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/ai")
+@RequiredArgsConstructor
+public class AiResumeController {
+
+    private final AiResumeService aiResumeService;
+
+    /**
+     * 이력서 AI 첨삭 및 요약 요청
+     * - 프론트엔드에서 "이력서 ID"와 "요약 타입"을 보내면,
+     * - 백엔드가 이력서 데이터를 조회해서 AiResumeRequest로 변환 후 Python 서버로 전송
+     */
+    @PostMapping("/resumes/analyze")
+    public ApiResponse<Void> analyzeResume(@RequestBody AiResumeRequestDTO request) {
+        aiResumeService.requestAnalysis(request.getResumeId(), request.getSummaryType());
+
+        return ApiResponse.success("AI 분석 요청이 성공적으로 접수되었습니다.", null);
+    }
+
+    @lombok.Data
+    public static class AiResumeRequestDTO {
+        private Long resumeId;
+        private String summaryType;
+    }
+}

--- a/backend/src/main/java/com/example/pproject/resume/dto/AiResumeRequest.java
+++ b/backend/src/main/java/com/example/pproject/resume/dto/AiResumeRequest.java
@@ -3,10 +3,14 @@ package com.example.pproject.resume.dto;
 import com.example.pproject.Constant.ResumeField;
 import com.example.pproject.resume.entity.Resume;
 import com.example.pproject.resume.entity.ResumeAttachment;
+import com.example.pproject.resume.entity.ResumeCareer;
+import com.example.pproject.resume.entity.ResumeProject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -24,17 +28,20 @@ public class AiResumeRequest {
 
     private String content;
 
+    @JsonProperty("projects")
+    private List<ProjectInfo> projects;
+
+    @JsonProperty("careers")
+    private List<CareerInfo> careers;
+
     @JsonProperty("file_links")
     private List<String> fileLinks;
 
-    @JsonProperty("projects")
-    private List<String> projects; // 프로젝트 설명 등 텍스트 리스트로 변환 가정
-
-    @JsonProperty("careers")
-    private List<String> careers; // 경력 설명 등 텍스트 리스트로 변환 가정
-
     @JsonProperty("summary_type")
     private String summaryType;
+
+    @JsonProperty("include_reasoning")
+    private Boolean includeReasoning;
 
     @Getter
     @Builder
@@ -43,7 +50,7 @@ public class AiResumeRequest {
         private String tagline;
 
         @JsonProperty("re_stack")
-        private List<String> reStack; // List로 변환
+        private List<String> reStack;
 
         private ResumeField field;
         private Preference preference;
@@ -59,52 +66,112 @@ public class AiResumeRequest {
         private String employmentType;
     }
 
+    @Getter
+    @Builder
+    public static class ProjectInfo {
+        @JsonProperty("project_name")
+        private String projectName;
+
+        @JsonProperty("start_date")
+        private String startDate;
+
+        @JsonProperty("end_date")
+        private String endDate;
+
+        @JsonProperty("total_tech_stack")
+        private List<String> totalTechStack;
+
+        private String contribution; // 엔티티에 텍스트 필드가 없으면 null 혹은 description 일부 매핑
+        private String description;
+    }
+
+    @Getter
+    @Builder
+    public static class CareerInfo {
+        @JsonProperty("company_name")
+        private String companyName;
+
+        private String role;
+
+        @JsonProperty("start_date")
+        private String startDate;
+
+        @JsonProperty("end_date")
+        private String endDate;
+
+        private String description;
+    }
+
     public static AiResumeRequest from(Resume resume, String summaryType) {
-        // 1. 기술 스택 String -> List 변환
-        List<String> stackList = (resume.getReStack() != null && !resume.getReStack().isEmpty())
-                ? Arrays.stream(resume.getReStack().split(",")) // 콤마로 구분되어 있다고 가정
-                .map(String::trim)
-                .collect(Collectors.toList())
-                : Collections.emptyList();
+        // 날짜 포맷터 (YYYY.MM)
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM");
 
-        // 2. 파일 링크 추출
-        List<String> fileUrls = resume.getAttachments().stream()
-                .map(ResumeAttachment::getFileUrl)
-                .collect(Collectors.toList());
-
-        // 3. Preference 객체 생성
-        Preference preference = Preference.builder()
-                .location(resume.getPreferenceLocation())
-                .salary(resume.getPreferenceSalary())
-                .employmentType(resume.getEmploymentType())
-                .build();
-
-        // 4. BasicInfo 객체 생성
+        // 1. BasicInfo 생성
         BasicInfo basicInfo = BasicInfo.builder()
                 .title(resume.getTitle())
                 .tagline(resume.getTagline())
-                .reStack(stackList)
+                .reStack(resume.getReStack() != null ? resume.getReStack() : Collections.emptyList())
                 .field(resume.getField())
-                .preference(preference)
+                .preference(Preference.builder()
+                        .location(resume.getPreferenceLocation())
+                        .salary(resume.getPreferenceSalary())
+                        .employmentType(resume.getEmploymentType())
+                        .build())
                 .build();
 
-        // 5. 프로젝트/경력 내용을 문자열 리스트로 변환
-        List<String> projectList = resume.getProjects().stream()
-                .map(p -> String.format("%s (%s): %s", p.getTitle(), p.getTechStack(), p.getDescription()))
+        // 2. Project 리스트 변환
+        List<ProjectInfo> projectList = resume.getProjects().stream()
+                .map(p -> ProjectInfo.builder()
+                        .projectName(p.getTitle())
+                        .startDate(formatDate(p.getStartDate(), formatter))
+                        .endDate(formatDate(p.getEndDate(), formatter))
+                        .totalTechStack(parseTechStack(p.getTechStack())) // 콤마 문자열 -> 리스트
+                        .description(p.getDescription())
+                        // contribution 필드는 Entity에 없으므로, 필요하다면 description을 쓰거나 비워둠
+                        .contribution(null)
+                        .build())
                 .collect(Collectors.toList());
 
-        List<String> careerList = resume.getCareers().stream()
-                .map(c -> String.format("%s (%s - %s)", c.getCompanyName(), c.getDepartment(), c.getRole()))
+        // 3. Career 리스트 변환
+        List<CareerInfo> careerList = resume.getCareers().stream()
+                .map(c -> CareerInfo.builder()
+                        .companyName(c.getCompanyName())
+                        .role(c.getRole())
+                        .startDate(formatDate(c.getStartDate(), formatter))
+                        .endDate(formatDate(c.getEndDate(), formatter))
+                        // description 필드가 ResumeCareer에 없다면 null
+                        .description(null)
+                        .build())
+                .collect(Collectors.toList());
+
+        // 4. 파일 링크
+        List<String> fileUrls = resume.getAttachments().stream()
+                .map(ResumeAttachment::getFileUrl)
                 .collect(Collectors.toList());
 
         return AiResumeRequest.builder()
                 .resumeId(resume.getId())
                 .basicInfo(basicInfo)
                 .content(resume.getContent())
-                .fileLinks(fileUrls)
                 .projects(projectList)
                 .careers(careerList)
+                .fileLinks(fileUrls)
                 .summaryType(summaryType)
+                .includeReasoning(true)
                 .build();
+    }
+
+    // 날짜 포맷팅 헬퍼 메소드
+    private static String formatDate(LocalDate date, DateTimeFormatter formatter) {
+        return date != null ? date.format(formatter) : null;
+    }
+
+    private static List<String> parseTechStack(String techStack) {
+        if (techStack == null || techStack.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(techStack.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/example/pproject/resume/dto/ResumeRequest.java
+++ b/backend/src/main/java/com/example/pproject/resume/dto/ResumeRequest.java
@@ -12,6 +12,7 @@ import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -30,7 +31,10 @@ public class ResumeRequest {
     private Boolean primary;
     private Boolean publicOption;
     private String content;
-    private String reStack;
+
+    private List<String> reStack;
+
+    private Integer careerYears;
 
     private Long targetJobId;
     private String preferenceLocation;
@@ -60,7 +64,8 @@ public class ResumeRequest {
                 .tagline(this.tagline)
                 .primary(this.primary != null ? this.primary : false)
                 .publicOption(this.publicOption != null ? this.publicOption : false)
-                .reStack(this.reStack)
+                .reStack(this.reStack != null ? this.reStack : new ArrayList<>()) // List 그대로 전달
+                .careerYears(this.careerYears != null ? this.careerYears : 0)     // 연차 추가
                 .targetJobId(this.targetJobId)
                 .preferenceLocation(this.preferenceLocation)
                 .preferenceSalary(this.preferenceSalary)

--- a/backend/src/main/java/com/example/pproject/resume/dto/ResumeResponse.java
+++ b/backend/src/main/java/com/example/pproject/resume/dto/ResumeResponse.java
@@ -33,7 +33,10 @@ public class ResumeResponse {
     private String preferenceLocation;
     private String preferenceSalary;
     private String employmentType;
-    private String reStack;
+
+    private List<String> reStack;
+
+    private Integer careerYears;
 
     private String school;
     private String schoolState;
@@ -63,7 +66,8 @@ public class ResumeResponse {
                 .preferenceLocation(resume.getPreferenceLocation())
                 .preferenceSalary(resume.getPreferenceSalary())
                 .employmentType(resume.getEmploymentType())
-                .reStack(resume.getReStack())
+                .reStack(resume.getReStack())       // List 그대로 매핑
+                .careerYears(resume.getCareerYears()) // 연차 매핑
                 .school(resume.getSchool())
                 .schoolState(resume.getSchoolState())
                 .schoolClass(resume.getSchoolClass())

--- a/backend/src/main/java/com/example/pproject/resume/entity/Resume.java
+++ b/backend/src/main/java/com/example/pproject/resume/entity/Resume.java
@@ -74,9 +74,15 @@ public class Resume extends BaseSoftDeleteEntity {
     @Column(columnDefinition = "TEXT")
     private String summary;
 
-    // 희망 기술 스택
-    @Column(name = "re_stack", columnDefinition = "TEXT")
-    private String reStack;
+    // [수정] 기술 스택
+    @Column(name = "re_stack", columnDefinition = "text[]")
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    private List<String> reStack = new ArrayList<>();
+
+    // [추가] 경력 연차
+    @Column(name = "career_years", nullable = false)
+    @ColumnDefault("0")
+    private Integer careerYears;
 
     // 학력 정보
     @Column(name = "school")
@@ -126,7 +132,7 @@ public class Resume extends BaseSoftDeleteEntity {
 
     @Builder
     public Resume(UserEntity user, String title, ResumeField field, boolean primary, boolean publicOption,
-                  String tagline, String content, String reStack, Long targetJobId,
+                  String tagline, String content, List<String> reStack, Integer careerYears, Long targetJobId,
                   String preferenceLocation, String preferenceSalary, String employmentType,
                   String school, String schoolState, String schoolClass) {
         this.user = user;
@@ -136,7 +142,8 @@ public class Resume extends BaseSoftDeleteEntity {
         this.publicOption = publicOption;
         this.tagline = tagline;
         this.content = content;
-        this.reStack = reStack;
+        this.reStack = reStack != null ? reStack : new ArrayList<>();
+        this.careerYears = careerYears != null ? careerYears : 0;
         this.targetJobId = targetJobId;
         this.preferenceLocation = preferenceLocation;
         this.preferenceSalary = preferenceSalary;
@@ -160,7 +167,8 @@ public class Resume extends BaseSoftDeleteEntity {
     }
 
     public void updateInfo(String title, String tagline, String content, Boolean publicOption, ResumeField field,
-                           String preferenceLocation, String preferenceSalary, String employmentType, String reStack,
+                           String preferenceLocation, String preferenceSalary, String employmentType,
+                           List<String> reStack, Integer careerYears,
                            String school, String schoolState, String schoolClass) {
         if (title != null) this.title = title;
         if (tagline != null) this.tagline = tagline;
@@ -170,15 +178,18 @@ public class Resume extends BaseSoftDeleteEntity {
         if (preferenceLocation != null) this.preferenceLocation = preferenceLocation;
         if (preferenceSalary != null) this.preferenceSalary = preferenceSalary;
         if (employmentType != null) this.employmentType = employmentType;
-        if (reStack != null) this.reStack = reStack;
+
+        if (reStack != null) this.reStack = reStack; // 리스트 자체를 업데이트
+        if (careerYears != null) this.careerYears = careerYears;
+
         if (school != null) this.school = school;
         if (schoolState != null) this.schoolState = schoolState;
         if (schoolClass != null) this.schoolClass = schoolClass;
         this.lastModifiedAt = LocalDateTime.now();
     }
 
-    // AI 분석 결과 업데이트용 (나중에 사용)
-    public void updateAiAnalysis(String summary, String techStack) {
+    // AI 분석 결과 업데이트용
+    public void updateAiAnalysis(String summary, List<String> techStack) {
         if (summary != null) this.summary = summary;
         if (techStack != null) this.reStack = techStack;
         this.summaryStatus = SummaryStatus.COMPLETED;

--- a/backend/src/main/java/com/example/pproject/resume/entity/ResumeProfile.java
+++ b/backend/src/main/java/com/example/pproject/resume/entity/ResumeProfile.java
@@ -39,4 +39,8 @@ public class ResumeProfile extends BaseTimeEntity {
     public void updatePhotoUrl(String photoUrl) {
         this.photoUrl = photoUrl;
     }
+
+    public void updateAddress(String address) {
+        this.address = address;
+    }
 }

--- a/backend/src/main/java/com/example/pproject/resume/repository/ResumeRepository.java
+++ b/backend/src/main/java/com/example/pproject/resume/repository/ResumeRepository.java
@@ -14,7 +14,7 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     // 특정 유저의 대표 이력서 조회
     Optional<Resume> findByUserIdAndPrimaryTrue(Integer userId);
 
-    Optional<Resume> findByMemberIdAndIsPrimaryTrue(Long memberId); // 대표 이력서 찾기
+    // 특정 유저의 최근 수정된 이력서 조회 (AI 첨삭 등에서 활용 가능)
+    Optional<Resume> findFirstByUserIdOrderByLastModifiedAtDesc(Integer userId);
 
-    Optional<Resume> findFirstByMemberIdOrderByUpdatedAtDesc(Long memberId); // 최근 이력서 찾기
 }

--- a/backend/src/main/java/com/example/pproject/resume/service/AiResumeService.java
+++ b/backend/src/main/java/com/example/pproject/resume/service/AiResumeService.java
@@ -1,0 +1,61 @@
+package com.example.pproject.resume.service;
+
+import com.example.pproject.resume.dto.AiResumeRequest;
+import com.example.pproject.resume.entity.Resume;
+import com.example.pproject.resume.repository.ResumeRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient; // Spring Boot 3.2+ 권장
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiResumeService {
+
+    private final ResumeRepository resumeRepository;
+    private final ObjectMapper objectMapper; // JSON 변환용
+
+    // Python AI 서버 주소 (application.yml에서 관리 권장)
+    private final String AI_SERVER_URL = "http://localhost:8000/api/ai/resume";
+
+    /**
+     * AI 분석 요청 (비동기 처리 권장)
+     * - 요구사항 명세: "Python API 호출은 메인 스레드를 차단하지 않는 비동기 방식(@Async)으로 처리"
+     */
+    @Async
+    @Transactional(readOnly = true)
+    public void requestAnalysis(Long resumeId, String summaryType) {
+        // 1. 이력서 조회
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(() -> new IllegalArgumentException("이력서를 찾을 수 없습니다."));
+
+        // 2. DTO 변환 (우리가 만든 AiResumeRequest 사용!)
+        AiResumeRequest aiRequestPayload = AiResumeRequest.from(resume, summaryType);
+
+        try {
+            // 3. Python 서버로 전송 (RestClient 사용 예시)
+            RestClient restClient = RestClient.create();
+
+            String response = restClient.post()
+                    .uri(AI_SERVER_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(aiRequestPayload)
+                    .retrieve()
+                    .body(String.class);
+
+            log.info("AI Server Response: {}", response);
+
+            // 4. (선택) 여기서 바로 DB 업데이트를 하거나,
+            //    Python 서버가 분석 완료 후 별도 Webhook으로 결과를 보내주기를 기다림
+
+        } catch (Exception e) {
+            log.error("AI 서버 통신 중 오류 발생: {}", e.getMessage());
+            // 실패 시 재시도 로직이나 상태 업데이트 필요
+        }
+    }
+}

--- a/backend/src/main/java/com/example/pproject/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/example/pproject/resume/service/ResumeService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,7 +22,6 @@ public class ResumeService {
 
     private final ResumeRepository resumeRepository;
     private final UserRepository userRepository;
-    // ✅ [추가] 삭제 시 지원 내역 확인용
     private final JobApplicationRepository jobApplicationRepository;
 
     // 1. 내 이력서 목록 조회
@@ -66,7 +66,9 @@ public class ResumeService {
                 request.getTitle(), request.getTagline(), request.getContent(),
                 request.getPublicOption(), request.getField(),
                 request.getPreferenceLocation(), request.getPreferenceSalary(),
-                request.getEmploymentType(), request.getReStack(),
+                request.getEmploymentType(),
+                request.getReStack(),     // List<String>
+                request.getCareerYears(), // Integer
                 request.getSchool(), request.getSchoolState(), request.getSchoolClass()
         );
 
@@ -85,7 +87,6 @@ public class ResumeService {
         Resume resume = getResumeEntity(resumeId);
         validateOwner(resume, userId);
 
-        // 지원 내역 존재 여부 확인
         boolean hasApplication = jobApplicationRepository.existsByResumeId(resumeId);
         if (hasApplication) {
             throw new IllegalStateException("이미 입사 지원에 사용된 이력서는 삭제할 수 없습니다.");
@@ -109,7 +110,8 @@ public class ResumeService {
                 .preferenceLocation(original.getPreferenceLocation())
                 .preferenceSalary(original.getPreferenceSalary())
                 .employmentType(original.getEmploymentType())
-                .reStack(original.getReStack())
+                .reStack(original.getReStack() != null ? new ArrayList<>(original.getReStack()) : new ArrayList<>()) // Deep Copy
+                .careerYears(original.getCareerYears()) // 연차 복사
                 .school(original.getSchool())
                 .schoolState(original.getSchoolState())
                 .schoolClass(original.getSchoolClass())
@@ -124,6 +126,50 @@ public class ResumeService {
                     .photoUrl(original.getProfile().getPhotoUrl())
                     .build());
         }
+
+        // 하위 항목 복사
+        if (original.getCareers() != null) {
+            original.getCareers().forEach(c -> copy.getCareers().add(ResumeCareer.builder()
+                    .resume(copy)
+                    .companyName(c.getCompanyName())
+                    .department(c.getDepartment())
+                    .role(c.getRole())
+                    .startDate(c.getStartDate())
+                    .endDate(c.getEndDate())
+                    .current(c.getCurrent())
+                    .verified(c.getVerified())
+                    .build()));
+        }
+        if (original.getProjects() != null) {
+            original.getProjects().forEach(p -> copy.getProjects().add(ResumeProject.builder()
+                    .resume(copy)
+                    .title(p.getTitle())
+                    .description(p.getDescription())
+                    .techStack(p.getTechStack())
+                    .startDate(p.getStartDate())
+                    .endDate(p.getEndDate())
+                    .contributionPct(p.getContributionPct())
+                    .sortOrder(p.getSortOrder())
+                    .build()));
+        }
+        if (original.getCertificates() != null) {
+            original.getCertificates().forEach(c -> copy.getCertificates().add(ResumeCertificate.builder()
+                    .resume(copy)
+                    .name(c.getName())
+                    .issuer(c.getIssuer())
+                    .acquisitionDate(c.getAcquisitionDate())
+                    .verified(c.getVerified())
+                    .build()));
+        }
+        if (original.getLinks() != null) {
+            original.getLinks().forEach(l -> copy.getLinks().add(ResumeLink.builder()
+                    .resume(copy)
+                    .linkType(l.getLinkType())
+                    .url(l.getUrl())
+                    .build()));
+        }
+        // 첨부파일은 물리 파일 복사가 필요할 수 있으나, 여기서는 DB 메타데이터만 복사하거나 정책에 따라 제외
+        // (필요 시 Attachment 복사 로직 추가)
 
         return resumeRepository.save(copy).getId();
     }

--- a/backend/src/main/java/com/example/pproject/resume/service/ResumeSkillService.java
+++ b/backend/src/main/java/com/example/pproject/resume/service/ResumeSkillService.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,21 +15,20 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class ResumeSkillService { // implements 제거함
+public class ResumeSkillService {
 
     private final ResumeRepository resumeRepository;
 
     /**
      * 1. 특정 회원의 기술 스택 조회 (대표 이력서 기준)
-     * (나중에 인터페이스가 생기면 @Override 붙이세요)
      */
-    public Set<String> getSkillsByMemberId(Long memberId) {
+    public Set<String> getSkillsByMemberId(Integer memberId) {
         // 대표 이력서 찾기
-        Optional<Resume> primaryResume = resumeRepository.findByMemberIdAndIsPrimaryTrue(memberId);
+        Optional<Resume> primaryResume = resumeRepository.findByUserIdAndPrimaryTrue(memberId);
 
         // 없으면 최근 수정된 이력서 찾기
         if (primaryResume.isEmpty()) {
-            primaryResume = resumeRepository.findFirstByMemberIdOrderByUpdatedAtDesc(memberId);
+            primaryResume = resumeRepository.findFirstByUserIdOrderByLastModifiedAtDesc(memberId);
         }
 
         return primaryResume
@@ -45,20 +44,16 @@ public class ResumeSkillService { // implements 제거함
                 .map(this::extractSkillsFromResume)
                 .orElse(new HashSet<>());
     }
-
-    // [내부 로직] 문자열 파싱
     private Set<String> extractSkillsFromResume(Resume resume) {
-        String stackString = resume.getReStack();
+        List<String> skills = resume.getReStack();
 
-        if (stackString == null || stackString.isBlank()) {
+        if (skills == null || skills.isEmpty()) {
             return new HashSet<>();
         }
 
-        String[] skills = stackString.split("[,/|;]");
-
-        return Arrays.stream(skills)
+        return skills.stream()
+                .filter(s -> s != null && !s.isBlank())
                 .map(String::trim)
-                .filter(s -> !s.isEmpty())
                 .map(String::toLowerCase)
                 .collect(Collectors.toSet());
     }

--- a/backend/src/main/java/com/example/pproject/user/service/MyPageService.java
+++ b/backend/src/main/java/com/example/pproject/user/service/MyPageService.java
@@ -1,0 +1,147 @@
+package com.example.pproject.user.service;
+
+import com.example.pproject.application.repository.JobApplicationRepository;
+import com.example.pproject.resume.entity.Resume;
+import com.example.pproject.resume.entity.ResumeProfile;
+import com.example.pproject.resume.repository.ResumeRepository;
+import com.example.pproject.user.dto.UserRequestDTO;
+import com.example.pproject.user.dto.UserResponseDTO;
+import com.example.pproject.user.entity.UserEntity;
+import com.example.pproject.user.repository.UserRepository;
+import com.example.pproject.wallet.entity.Wallet;
+import com.example.pproject.wallet.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Log4j2
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final WalletRepository walletRepository;
+    private final JobApplicationRepository applicationRepository;
+    private final ResumeRepository resumeRepository;
+
+    private final ModelMapper modelMapper;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 1. 마이페이지 대시보드 조회
+     * - 회원 기본 정보 + 지갑 잔액 + (대표 이력서의 주소 정보) 조회
+     */
+    @Transactional(readOnly = true)
+    public Map<String, Object> getMyDashboard(String userid) {
+        // 1) 사용자 조회
+        UserEntity user = userRepository.findByUserid(userid)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 2) 기본 정보 매핑
+        UserResponseDTO userInfo = modelMapper.map(user, UserResponseDTO.class);
+
+        // 3) [주소 연동] 대표 이력서에서 주소 정보 가져와서 DTO에 채우기
+        Optional<Resume> primaryResume = resumeRepository.findByUserIdAndPrimaryTrue(user.getId());
+
+        if (primaryResume.isPresent() && primaryResume.get().getProfile() != null) {
+            ResumeProfile profile = primaryResume.get().getProfile();
+            userInfo.setAddress(profile.getAddress());
+            // 필요한 경우 상세 주소나 우편번호 로직도 여기에 추가 가능
+        }
+
+        // 4) 지갑 잔액 조회
+        Long userDbId = Long.valueOf(user.getId());
+        long creditBalance = walletRepository.findByMember(userDbId)
+                .map(Wallet::getBalance).orElse(0L);
+
+        // 5) 통계 데이터 구성
+        // (필요 시 Repository에 count 메소드 추가 후 주석 해제하여 사용)
+        long applicationCount = 0; // applicationRepository.countByMemberId(userDbId);
+        long resumeCount = 0;      // resumeRepository.countByUserId(user.getId());
+
+        Map<String, Object> dashboardData = new HashMap<>();
+        dashboardData.put("profile", userInfo);
+        dashboardData.put("creditBalance", creditBalance);
+        dashboardData.put("stats", Map.of(
+                "applicationCount", applicationCount,
+                "resumeCount", resumeCount
+        ));
+
+        return dashboardData;
+    }
+
+    /**
+     * 2. 내 정보 수정
+     * - 회원 테이블 정보 수정 + (대표 이력서의 주소 정보 수정)
+     */
+    public void updateMyInfo(String userid, UserRequestDTO requestDTO) {
+        UserEntity user = userRepository.findByUserid(userid)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 1) Member 테이블 필드 수정
+        if (requestDTO.getUsername() != null && !requestDTO.getUsername().isBlank()) {
+            user.setUsername(requestDTO.getUsername());
+        }
+        if (requestDTO.getPhone() != null && !requestDTO.getPhone().isBlank()) {
+            user.setPhone(requestDTO.getPhone().replaceAll("[^0-9]", ""));
+        }
+        if (requestDTO.getPassword() != null && !requestDTO.getPassword().isBlank()) {
+            user.setPassword(passwordEncoder.encode(requestDTO.getPassword()));
+        }
+        if (requestDTO.getMarketingOptIn() != null && !requestDTO.getMarketingOptIn().equals(user.getMarketingOptIn())) {
+            user.setMarketingOptIn(requestDTO.getMarketingOptIn());
+            user.setMarketingAgreedAt(Boolean.TRUE.equals(requestDTO.getMarketingOptIn()) ? LocalDateTime.now() : null);
+        }
+
+        // 2) [주소 정보 업데이트] 대표 이력서 찾아서 업데이트
+        if (requestDTO.getAddress() != null) {
+            resumeRepository.findByUserIdAndPrimaryTrue(user.getId())
+                    .ifPresent(resume -> {
+                        // 이력서에 프로필이 없으면 생성
+                        if (resume.getProfile() == null) {
+                            ResumeProfile newProfile = ResumeProfile.builder()
+                                    .resume(resume)
+                                    .build();
+                            resume.updateProfile(newProfile); // Resume 엔티티의 편의 메소드 활용
+                        }
+
+                        // 주소 문자열 조합
+                        String fullAddress = requestDTO.getAddress();
+                        if (requestDTO.getDetailAddress() != null && !requestDTO.getDetailAddress().isBlank()) {
+                            fullAddress += " " + requestDTO.getDetailAddress();
+                        }
+
+                        // Profile 엔티티 업데이트
+                        resume.getProfile().updateAddress(fullAddress);
+                    });
+        }
+    }
+
+    /**
+     * 3. 회원 탈퇴
+     */
+    public void withdrawUser(String userid) {
+        UserEntity user = userRepository.findByUserid(userid)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (user.getDeletedAt() != null) {
+            throw new IllegalStateException("이미 탈퇴한 회원입니다.");
+        }
+
+        user.setDeletedAt(LocalDateTime.now());
+        // 필요 시 상태 코드 변경 로직 추가
+        // user.setStatus("WITHDRAWN");
+
+        log.info("회원 탈퇴 처리 완료: userid={}", userid);
+    }
+}


### PR DESCRIPTION
---
name: "기본 PR 템플릿"
about: 작업 내용을 명확히 공유하고, CI 통과를 미리 점검합니다.
title: '[FEAT] AI 이력서 분석 요청 기능 구현 및 Resume 엔티티 리팩토링'
labels: 'feature, refactor'
assignees: ''
---

## 📝 설명 (Description)
- **AI 이력서 분석 요청 API 구현**: 프론트엔드로부터 이력서 분석 요청을 받아, 데이터를 전처리(`AiResumeRequest`)한 후 Python AI 서버로 비동기 전송하는 로직(`AiResumeService`, `AiResumeController`)을 구현했습니다.
- **Resume 도메인 리팩토링**: 최신 ERD를 반영하여 `Resume` 엔티티의 `reStack`을 `List<String>`(배열)으로 변경하고, `careerYears`(경력 연차) 필드를 추가했습니다. 이에 맞춰 DTO와 CRUD 로직도 수정했습니다.
- **안전한 삭제 로직**: 이력서 삭제 시, 이미 지원(`JobApplication`)에 사용된 이력서는 삭제되지 않도록 검증 로직을 추가했습니다.
## 🔗 관련 이슈 (Related Issue)
- # (여기에 관련 이슈 번호가 있다면 적어주세요, 예: #12, #24)

## ✅ CI/CD Self-Check (필수)
- [x] **backend 폴더**에서 `./gradlew clean build`를 돌려보셨나요? (로컬 빌드 성공)
- [x] 불필요한 `System.out.println`이나 주석을 제거했나요?
- [x] `develop` 브랜치의 최신 코드를 반영(Rebase/Merge)했나요?

## 🛠️ Todo (작업 리스트)
- [x] `AiResumeController` 및 `AiResumeService` 구현 (Python 서버 연동)
- [x] `Resume` 엔티티 수정 (`re_stack` 배열화, `career_years` 추가)
- [x] `ResumeRequest`, `ResumeResponse`, `AiResumeRequest` DTO 수정
- [x] `ResumeService` CRUD 로직 업데이트 및 삭제 방어 로직 추가
## 🎸 ETC